### PR TITLE
feat: Add GitHub Actions workflow to build and push Docker images

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,0 +1,37 @@
+name: Build and Push Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_sha:
+        description: 'Git SHA commit to build'
+        required: true
+        type: string
+        
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code at specific commit
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.git_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: docker/
+          push: true
+          tags: |
+            ghcr.io/lsdaf/lsadf_api:${{ github.event.inputs.git_sha }}
+            ghcr.io/lsdaf/lsadf_api:latest

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,6 +1,9 @@
 name: Build and Push Docker Image
 
 on:
+  push:
+    branches:
+      - '**'
   workflow_dispatch:
     inputs:
       git_sha:

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,4 +1,6 @@
-name: Build and Push Docker Image
+name: 🐳 Build and Push Docker Image by SHA
+
+run-name: Build and push image for commit ${{ github.event.inputs.git_sha }}
 
 on:
   workflow_dispatch:
@@ -7,31 +9,66 @@ on:
         description: 'Git SHA commit to build'
         required: true
         type: string
-        
+
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-22.04'
+    timeout-minutes: 15
+    permissions:
+      actions: write
+      checks: write
+      contents: write
+      packages: write
+
     steps:
-      - name: Checkout code at specific commit
-        uses: actions/checkout@v3
+      - name: 📥 Checkout code at specific commit
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.git_sha }}
+          lfs: true
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+      - name: 📦 Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - name: 📦 Setup Docker compose
+        uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.30.3'
+
+      - name: 📦 Copy Fake env file
+        run: |
+          mv env/env.EXAMPLE.properties env/env.properties
+
+      - name: 🚧 Build Package & LSADF API Docker Image
+        run: |
+          set -x  # Enable debug output
+          make build-ci-ghcr
+          echo "=== Listing all Docker images ==="
+          docker images
+
+      - name: 🔐 Login to GHCR
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.GHCR_PAT }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v4
-        with:
-          context: docker/
-          push: true
-          tags: |
-            ghcr.io/lsdaf/lsadf_api:${{ github.event.inputs.git_sha }}
-            ghcr.io/lsdaf/lsadf_api:latest
+      - name: 🚀 Tag and Push to GHCR
+        run: |
+          # Get the input SHA
+          COMMIT_SHA=${{ github.event.inputs.git_sha }}
+
+          # Tag the image with commit SHA
+          docker tag ghcr.io/lsdaf/lsadf_api:latest ghcr.io/lsdaf/lsadf_api:$COMMIT_SHA
+
+          # Push both tags
+          docker push ghcr.io/lsdaf/lsadf_api:latest
+          docker push ghcr.io/lsdaf/lsadf_api:$COMMIT_SHA
+
+          echo "✅ Successfully pushed Docker image with tags:"
+          echo "  - ghcr.io/lsdaf/lsadf_api:latest"
+          echo "  - ghcr.io/lsdaf/lsadf_api:$COMMIT_SHA"

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,9 +1,6 @@
 name: Build and Push Docker Image
 
 on:
-  push:
-    branches:
-      - '**'
   workflow_dispatch:
     inputs:
       git_sha:


### PR DESCRIPTION
This workflow allows building and pushing Docker images to GitHub's container registry. It uses workflow dispatch with a required Git SHA input and supports pushing both specific and latest tags. The implementation includes Docker login, build, and tagging steps.

## Ticket


## What did I do

