### PR TITLE
fix: Update Docker workflow to use Buildx and multi-platform builds

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -34,10 +34,11 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: 📦 Setup Docker compose
-        uses: KengoTODA/actions-setup-docker-compose@v1
-        with:
-          version: '2.30.3'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: 📦 Copy Fake env file
         run: |
@@ -56,6 +57,13 @@ jobs:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.GHCR_PAT }}
+
+      - name: Tag & Push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: ghcr.io/lsdaf/lsadf_api:${{ github.event.inputs.git_sha }}
 
       - name: 🚀 Tag and Push to GHCR
         run: |

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -65,18 +65,18 @@ jobs:
           push: true
           tags: ghcr.io/lsdaf/lsadf_api:${{ github.event.inputs.git_sha }}
 
-      - name: 🚀 Tag and Push to GHCR
-        run: |
-          # Get the input SHA
-          COMMIT_SHA=${{ github.event.inputs.git_sha }}
-
-          # Tag the image with commit SHA
-          docker tag ghcr.io/lsdaf/lsadf_api:latest ghcr.io/lsdaf/lsadf_api:$COMMIT_SHA
-
-          # Push both tags
-          docker push ghcr.io/lsdaf/lsadf_api:latest
-          docker push ghcr.io/lsdaf/lsadf_api:$COMMIT_SHA
-
-          echo "✅ Successfully pushed Docker image with tags:"
-          echo "  - ghcr.io/lsdaf/lsadf_api:latest"
-          echo "  - ghcr.io/lsdaf/lsadf_api:$COMMIT_SHA"
+#      - name: 🚀 Tag and Push to GHCR
+#        run: |
+#          # Get the input SHA
+#          COMMIT_SHA=${{ github.event.inputs.git_sha }}
+#
+#          # Tag the image with commit SHA
+#          docker tag ghcr.io/lsdaf/lsadf_api:latest ghcr.io/lsdaf/lsadf_api:$COMMIT_SHA
+#
+#          # Push both tags
+#          docker push ghcr.io/lsdaf/lsadf_api:latest
+#          docker push ghcr.io/lsdaf/lsadf_api:$COMMIT_SHA
+#
+#          echo "✅ Successfully pushed Docker image with tags:"
+#          echo "  - ghcr.io/lsdaf/lsadf_api:latest"
+#          echo "  - ghcr.io/lsdaf/lsadf_api:$COMMIT_SHA"


### PR DESCRIPTION
Replaced Docker Compose setup with QEMU and Buildx for enhanced multi-platform support. Added build-push-action to tag and push images to GHCR with specified platforms, enabling more flexible container deployment.
