### PR TITLE
feat: Add workflow to delete Docker images via GitHub Actions

### DIFF
--- a/.github/workflows/docker-delete-image.yml
+++ b/.github/workflows/docker-delete-image.yml
@@ -1,0 +1,63 @@
+name: 🗑️ Delete Docker Image
+
+run-name: Delete Docker image with tag ${{ github.event.inputs.image_tag }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Tag of the image to delete (e.g., a Git SHA)'
+        required: true
+        type: string
+
+jobs:
+  delete-image:
+    runs-on: 'ubuntu-22.04'
+    timeout-minutes: 5
+    permissions:
+      packages: write
+
+    steps:
+      - name: 🔐 Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Check and delete image
+        id: check_delete
+        run: |
+          IMAGE_NAME="ghcr.io/lsdaf/lsadf_api:${{ github.event.inputs.image_tag }}"
+          echo "Checking if image $IMAGE_NAME exists..."
+
+          # Install jq for JSON parsing
+          sudo apt-get update && sudo apt-get install -y jq
+
+          # Get the package version ID using the GitHub API
+          PACKAGE_VERSION_ID=$(curl -s -H "Authorization: Bearer ${{ secrets.GHCR_PAT }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/orgs/lsdaf/packages/container/lsadf_api/versions" | \
+            jq -r --arg TAG "${{ github.event.inputs.image_tag }}" '.[] | select(.metadata.container.tags[] | contains($TAG)) | .id')
+
+          # Check if the package version ID was found
+          if [ -z "$PACKAGE_VERSION_ID" ]; then
+            echo "::error::Image $IMAGE_NAME does not exist"
+            exit 1
+          fi
+
+          echo "Found package version ID: $PACKAGE_VERSION_ID"
+
+          # Delete the package version
+          echo "Deleting image $IMAGE_NAME..."
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+            -H "Authorization: Bearer ${{ secrets.GHCR_PAT }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/orgs/lsdaf/packages/container/lsadf_api/versions/$PACKAGE_VERSION_ID")
+
+          if [ "$HTTP_STATUS" -eq 204 ]; then
+            echo "Image deleted successfully"
+          else
+            echo "::error::Failed to delete image. HTTP status: $HTTP_STATUS"
+            exit 1
+          fi


### PR DESCRIPTION
This workflow enables users to delete a Docker image from GHCR by providing its tag through a manual trigger. It performs authentication, validates the image's existence, and deletes it if found, ensuring streamlined image management.
