### PR TITLE
chore: Add OCI labels to Dockerfile for better image metadata

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,8 @@ COPY --from=compiler startup.sh .
 FROM eclipse-temurin:17.0.15_6-jre-noble
 
 EXPOSE 8080
+LABEL org.opencontainers.image.source="https://github.com/LSDAF/lsadf_backend"
+LABEL org.opencontainers.image.description="LSADF API container image."
 
 # Copy layers from the build stage
 COPY --from=builder dependencies/ ./


### PR DESCRIPTION
## What did I do

Added `org.opencontainers.image.source` and `org.opencontainers.image.description` labels to the Dockerfile. These labels enhance the container image metadata, providing information about the source repository and a brief description of the image purpose.
