### PR TITLE
chore: Disable JWK set URI configuration in application-docker.yml.

### DIFF
--- a/lsadf_api/src/main/resources/application-docker.yml
+++ b/lsadf_api/src/main/resources/application-docker.yml
@@ -22,7 +22,7 @@ spring:
       resourceserver:
         jwt:
           issuer-uri: ${keycloak.issuer-uri}
-          jwk-set-uri: ${keycloak.url}/realms/${keycloak.realm}/protocol/openid-connect/certs
+          #jwk-set-uri: ${keycloak.url}/realms/${keycloak.realm}/protocol/openid-connect/certs
   cloud:
     openfeign:
       client:

--- a/lsadf_api/src/main/resources/application-docker.yml
+++ b/lsadf_api/src/main/resources/application-docker.yml
@@ -22,7 +22,6 @@ spring:
       resourceserver:
         jwt:
           issuer-uri: ${keycloak.issuer-uri}
-          #jwk-set-uri: ${keycloak.url}/realms/${keycloak.realm}/protocol/openid-connect/certs
   cloud:
     openfeign:
       client:


### PR DESCRIPTION
Commented out and deleted the `jwk-set-uri` property in the application-docker.yml file to prevent its usage. This change likely aligns with a shift in authentication configuration or resolves an issue with the existing setup.
