### PR TITLE
hotfix: update cache configuration to `valkey` section

### DIFF
--- a/lsadf_admin/src/main/resources/application-docker.yml
+++ b/lsadf_admin/src/main/resources/application-docker.yml
@@ -7,8 +7,8 @@ db:
 logging:
   config: file:logback-docker.xml
 
-cache:
-  redis:
+valkey:
+  config:
     host: ${REDIS_HOST_DOCKER}
 
 keycloak:

--- a/lsadf_admin/src/main/resources/application-local.yml
+++ b/lsadf_admin/src/main/resources/application-local.yml
@@ -1,8 +1,8 @@
 db:
   url: ${DB_URL_LOCALHOST}
 
-cache:
-  redis:
+valkey:
+  config:
     host: ${REDIS_HOST}
 
 keycloak:

--- a/lsadf_api/src/main/resources/application-docker.yml
+++ b/lsadf_api/src/main/resources/application-docker.yml
@@ -7,8 +7,8 @@ db:
 logging:
   config: file:logback-docker.xml
 
-cache:
-  redis:
+valkey:
+  config:
     host: ${REDIS_HOST_DOCKER}
 
 keycloak:

--- a/lsadf_api/src/main/resources/application-local.yml
+++ b/lsadf_api/src/main/resources/application-local.yml
@@ -1,8 +1,8 @@
 db:
   url: ${DB_URL_LOCALHOST}
 
-cache:
-  redis:
+valkey:
+  config:
     host: ${REDIS_HOST}
 
 keycloak:


### PR DESCRIPTION
## What did I do

- Replaced `cache.redis` configurations with `valkey.config` in `application-local.yml` and `application-docker.yml` files.
- Ensured consistency across `lsadf_api` and `lsadf_admin` modules.
- Updated placeholders for appropriate environment-specific variables.
